### PR TITLE
Removing empty 'health_settings'

### DIFF
--- a/examples/resources/kentik-synthetic_test-bulk-create/agents_filtered_by_asn/resource.tf
+++ b/examples/resources/kentik-synthetic_test-bulk-create/agents_filtered_by_asn/resource.tf
@@ -23,7 +23,6 @@ resource "kentik-synthetics_test" "agents-filtered-by-asn-test" {
       "ping",
       "traceroute"
     ])
-    health_settings {}
     monitoring_settings {
       activation_grace_period = "2"
       activation_time_unit    = "m"

--- a/examples/resources/kentik-synthetic_test-bulk-create/agents_filtered_by_country/resource.tf
+++ b/examples/resources/kentik-synthetic_test-bulk-create/agents_filtered_by_country/resource.tf
@@ -23,7 +23,6 @@ resource "kentik-synthetics_test" "agents-filtered-by-country-test" {
       "ping",
       "traceroute"
     ])
-    health_settings {}
     monitoring_settings {
       activation_grace_period = "2"
       activation_time_unit    = "m"

--- a/examples/resources/kentik-synthetic_test-bulk-create/one_agent_per_country/resource.tf
+++ b/examples/resources/kentik-synthetic_test-bulk-create/one_agent_per_country/resource.tf
@@ -24,7 +24,6 @@ resource "kentik-synthetics_test" "one_agent_per_country-test" {
       "ping",
       "traceroute"
     ])
-    health_settings {}
     monitoring_settings {
       activation_grace_period = "2"
       activation_time_unit    = "m"


### PR DESCRIPTION
This should be removed earlier, and due to copy-paste, it was not removed in 3 cases. Just a quick fix to merge.
