### PR TITLE
Gracefully handling removal of Test resource outside terraform

### DIFF
--- a/synthetics/resource_test_impl.go
+++ b/synthetics/resource_test_impl.go
@@ -57,6 +57,10 @@ func resourceTestRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		TestGet(ctx, d.Get(idKey).(string)).
 		Execute()
 	if err != nil {
+		if httpResp.StatusCode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return detailedDiagError("failed to read test", err, httpResp)
 	}
 

--- a/synthetics/resource_test_impl.go
+++ b/synthetics/resource_test_impl.go
@@ -2,6 +2,7 @@ package synthetics
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -57,7 +58,7 @@ func resourceTestRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		TestGet(ctx, d.Get(idKey).(string)).
 		Execute()
 	if err != nil {
-		if httpResp.StatusCode == 404 {
+		if httpResp.StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
It might seem, like a small change but produces beautifull results.

Instead of:

> piotr@piotr-ThinkPad-E595:~/Projects/kentik/terraform-provider-kentik-synthetics/examples/resources/kentik-synthetics_test$ terraform apply
kentik-synthetics_test.example-hostname-test: Refreshing state... [id=3]
╷
│ Error: failed to read test
│ 
│   with kentik-synthetics_test.example-hostname-test,
│   on resource.tf line 1, in resource "kentik-synthetics_test" "example-hostname-test":
│    1: resource "kentik-synthetics_test" "example-hostname-test" {
│ 
│ error: 404 Not Found, status: 404 Not Found, body: {{"code":2,"message":"test GET failed: no such test \"3\""}
│ }


We get:

> piotr@piotr-ThinkPad-E595:~/Projects/kentik/terraform-provider-kentik-synthetics/examples/resources/kentik-synthetics_test$ terraform apply
kentik-synthetics_test.example-hostname-test: Refreshing state... [id=3]
Note: Objects have changed outside of Terraform
Terraform detected the following changes made outside of Terraform since the last "terraform apply":
... missing resource ...
Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan
may include actions to undo or respond to these changes.
