### PR TITLE
Device_id reminiscents removal

### DIFF
--- a/docs/resources/test.md
+++ b/docs/resources/test.md
@@ -16,7 +16,6 @@ Resource representing synthetic test
 resource "kentik-synthetics_test" "example-hostname-test" {
   name      = "example-hostname-test"
   type      = "hostname"
-  device_id = "75702"
   status    = "TEST_STATUS_ACTIVE"
   settings {
     hostname {

--- a/examples/resources/kentik-synthetics_test/resource.tf
+++ b/examples/resources/kentik-synthetics_test/resource.tf
@@ -1,7 +1,6 @@
 resource "kentik-synthetics_test" "example-hostname-test" {
   name      = "example-hostname-test"
   type      = "hostname"
-  device_id = "75702"
   status    = "TEST_STATUS_ACTIVE"
   settings {
     hostname {


### PR DESCRIPTION
Don't really know how it is left in the repo, maybe merge order? Last time we see device_id, promise.