### PR TITLE
Setting default values for 'health_settings' attribute

### DIFF
--- a/synthetics/format.go
+++ b/synthetics/format.go
@@ -21,6 +21,10 @@ func getObjectFromNestedResourceData(data interface{}) (map[string]interface{}, 
 	if len(dataSlice) == 0 {
 		return nil, nil
 	}
+	
+	if dataSlice[0] == nil {
+		return nil, nil
+	}
 
 	m, ok := dataSlice[0].(map[string]interface{})
 	if !ok {

--- a/synthetics/test_conversions.go
+++ b/synthetics/test_conversions.go
@@ -467,11 +467,23 @@ func resourceDataToTestHealthSettings(data interface{}) (*synthetics.V202101beta
 	if err != nil {
 		return nil, fmt.Errorf("resourceDataToTestHealthSettings: %v", err)
 	}
-	if m == nil {
-		return nil, nil
-	}
 
 	obj := synthetics.NewV202101beta1HealthSettings()
+
+	if m == nil {
+		obj.SetLatencyCritical(0)
+		obj.SetLatencyWarning(0)
+		obj.SetPacketLossCritical(0)
+		obj.SetPacketLossWarning(0)
+		obj.SetJitterCritical(0)
+		obj.SetJitterWarning(0)
+		obj.SetHttpLatencyCritical(0)
+		obj.SetHttpLatencyWarning(0)
+		obj.SetHttpValidCodes([]int64{})
+		obj.SetDnsValidCodes([]int64{})
+		return obj, nil
+	}
+
 	obj.SetLatencyCritical(float32(m["latency_critical"].(float64)))
 	obj.SetLatencyWarning(float32(m["latency_warning"].(float64)))
 	obj.SetPacketLossCritical(float32(m["packet_loss_critical"].(float64)))


### PR DESCRIPTION
https://clkentik.atlassian.net/browse/KNTK-309

I've set default values for `health_settings`

Tested in 3 cases:
1) empty `health_settings` passed
2) no `health_settings` passed
3) `health_settings` filled up

Tested with actual Kentik API