### PR TITLE
TF provider schema TypeInt properties validation added

### DIFF
--- a/synthetics/resource_test_test.go
+++ b/synthetics/resource_test_test.go
@@ -32,7 +32,7 @@ func checkResourceTestCreate() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttrSet(testResource, "id"),
 		resource.TestCheckResourceAttr(testResource, "name", "dummy-name"),
-		resource.TestCheckResourceAttr(testResource, "type", "dummy-type"),
+		resource.TestCheckResourceAttr(testResource, "type", "hostname"),
 		resource.TestCheckNoResourceAttr(testResource, "device_id"),
 		resource.TestCheckResourceAttr(testResource, "status", "TEST_STATUS_ACTIVE"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.hostname.0.target", "dummy-ht"),
@@ -40,19 +40,19 @@ func checkResourceTestCreate() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(testResource, "settings.0.ip.0.targets.0", "101.102.103.104"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.agent.0.target", "dummy-at"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.target", "dummy-ft"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.target_refresh_interval_millis", "1"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.target_refresh_interval_millis", "3600000"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.max_tasks", "2"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.type", "dummy-ftt"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.inet_direction", "dummy-id"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.direction", "dummy-d"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.type", "cdn"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.inet_direction", "src"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.direction", "dst"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.site.0.target", "dummy-st"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.tag.0.target", "dummy-tt"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns.0.target", "dummy-dt"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns.0.type", "DNS_RECORD_CNAME"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.url.0.target", "dummy-ut"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.url.0.target", "https://example.com"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.network_grid.0.targets.#", "1"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.network_grid.0.targets.0", "dummy-ng-target"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.page_load.0.target", "dummy-pl-target"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.page_load.0.target", "https://example.com"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns_grid.0.targets.#", "1"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns_grid.0.targets.0", "dummy-dg-target"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns_grid.0.type", "DNS_RECORD_A"),
@@ -116,7 +116,7 @@ func checkResourceTestCreate() resource.TestCheckFunc {
 		resource.TestCheckNoResourceAttr(testResource, "settings.0.reciprocal"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.rollup_level", "1"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.period", "1"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.expiry", "2"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.expiry", "5000"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.method", "GET"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.headers.dummy-header-key", "dummy-header-value"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.body", "dummy-body"),
@@ -131,7 +131,7 @@ func checkResourceTestUpdate() resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttrSet(testResource, "id"),
 		resource.TestCheckResourceAttr(testResource, "name", "updated-name"),
-		resource.TestCheckResourceAttr(testResource, "type", "updated-type"),
+		resource.TestCheckResourceAttr(testResource, "type", "ip"),
 		resource.TestCheckNoResourceAttr(testResource, "device_id"),
 		resource.TestCheckResourceAttr(testResource, "status", "TEST_STATUS_PAUSED"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.hostname.0.target", "updated-ht"),
@@ -140,19 +140,19 @@ func checkResourceTestUpdate() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(testResource, "settings.0.ip.0.targets.1", "201.202.203.204"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.agent.0.target", "updated-at"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.target", "updated-ft"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.target_refresh_interval_millis", "10"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.target_refresh_interval_millis", "604800000"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.max_tasks", "20"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.type", "updated-ftt"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.inet_direction", "updated-id"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.direction", "updated-d"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.type", "region"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.inet_direction", "dst"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.flow.0.direction", "src"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.site.0.target", "updated-st"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.tag.0.target", "updated-tt"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns.0.target", "updated-dt"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns.0.type", "DNS_RECORD_DNAME"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.url.0.target", "updated-ut"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.url.0.target", "https://example.com"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.network_grid.0.targets.#", "1"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.network_grid.0.targets.0", "updated-ng-target"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.page_load.0.target", "updated-pl-target"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.page_load.0.target", "https://example.com"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns_grid.0.targets.#", "1"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns_grid.0.targets.0", "updated-dg-target"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.dns_grid.0.type", "DNS_RECORD_AAAA"),
@@ -182,12 +182,12 @@ func checkResourceTestUpdate() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.http_valid_codes.2", "203"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.dns_valid_codes.#", "1"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.dns_valid_codes.0", "21"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.latency_critical_stddev", "110"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.latency_warning_stddev", "120"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.jitter_critical_stddev", "130"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.jitter_warning_stddev", "140"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.http_latency_critical_stddev", "150"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.http_latency_warning_stddev", "160"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.latency_critical_stddev", "100"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.latency_warning_stddev", "100"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.jitter_critical_stddev", "100"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.jitter_warning_stddev", "100"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.http_latency_critical_stddev", "100"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.health_settings.0.http_latency_warning_stddev", "100"),
 		resource.TestCheckNoResourceAttr(testResource, "settings.0.monitoring_settings.0.activation_grace_period"),
 		resource.TestCheckNoResourceAttr(testResource, "settings.0.monitoring_settings.0.activation_time_unit"),
 		resource.TestCheckNoResourceAttr(testResource, "settings.0.monitoring_settings.0.activation_time_window"),
@@ -197,18 +197,18 @@ func checkResourceTestUpdate() resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(testResource, "settings.0.monitoring_settings.0.notification_channels.1", "nc-2"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.monitoring_settings.0.notification_channels.2", "nc-3"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.ping.0.period", "10"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.ping.0.count", "20"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.ping.0.count", "5"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.ping.0.expiry", "30"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.ping.0.delay", "40"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.period", "10"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.count", "20"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.protocol", "quick"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.count", "5"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.protocol", "tcp"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.port", "40"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.expiry", "50"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.limit", "60"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.trace.0.delay", "70"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.port", "80"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.protocol", "pigeon"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.protocol", "udp"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.family", "IP_FAMILY_V6"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.servers.#", "1"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.servers.0", "192.0.2.1"),
@@ -216,7 +216,7 @@ func checkResourceTestUpdate() resource.TestCheckFunc {
 		resource.TestCheckNoResourceAttr(testResource, "settings.0.reciprocal"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.rollup_level", "10"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.period", "10"),
-		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.expiry", "20"),
+		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.expiry", "5000"),
 		resource.TestCheckResourceAttr(testResource, "settings.0.http.0.method", "POST"),
 		resource.TestCheckResourceAttr(
 			testResource, "settings.0.http.0.headers.dummy-header-key", "updated-header-value",
@@ -239,7 +239,7 @@ const (
 
 		resource "kentik-synthetics_test" "dummy-test" {
 			name      = "dummy-name"
-			type      = "dummy-type"
+			type      = "hostname"
 			status    = "TEST_STATUS_ACTIVE"
 			settings {
 				hostname {
@@ -255,11 +255,11 @@ const (
 				}
 				flow {
 					target = "dummy-ft"
-					target_refresh_interval_millis = 1
+					target_refresh_interval_millis = 3600000
 					max_tasks = 2
-					type = "dummy-ftt"
-					inet_direction = "dummy-id"
-					direction = "dummy-d"
+					type = "cdn"
+					inet_direction = "src"
+					direction = "dst"
 				}
 				site {
 					target = "dummy-st"
@@ -272,13 +272,13 @@ const (
 					type = "DNS_RECORD_CNAME"
 				}
 				url {
-					target = "dummy-ut"
+					target = "https://example.com"
 				}
 				network_grid {
 					targets = ["dummy-ng-target"]
 				}
 				page_load {
-					target = "dummy-pl-target"
+					target = "https://example.com"
 				}
 				dns_grid {
 					targets = ["dummy-dg-target"]
@@ -352,7 +352,7 @@ const (
 				rollup_level = 1
 				http {
 				  period = 1
-				  expiry = 2
+				  expiry = 5000
 				  method = "GET"
 				  headers = {
 					dummy-header-key = "dummy-header-value"
@@ -374,7 +374,7 @@ const (
 
 		resource "kentik-synthetics_test" "dummy-test" {
 			name      = "updated-name"
-			type      = "updated-type"
+			type      = "ip"
 			status    = "TEST_STATUS_PAUSED"
 			settings {
 				hostname {
@@ -391,11 +391,11 @@ const (
 				}
 				flow {
 					target = "updated-ft"
-					target_refresh_interval_millis = 10
+					target_refresh_interval_millis = 604800000
 					max_tasks = 20
-					type = "updated-ftt"
-					inet_direction = "updated-id"
-					direction = "updated-d"
+					type = "region"
+					inet_direction = "dst"
+					direction = "src"
 				}
 				site {
 					target = "updated-st"
@@ -408,13 +408,13 @@ const (
 					type = "DNS_RECORD_DNAME"
 				}
 				url {
-					target = "updated-ut"
+					target = "https://example.com"
 				}
 				network_grid {
 					targets = ["updated-ng-target"]
 				}
 				page_load {
-					target = "updated-pl-target"
+					target = "https://example.com"
 				}
 				dns_grid {
 					targets = ["updated-dg-target"]
@@ -450,12 +450,12 @@ const (
 					dns_valid_codes = [
 						21
 					]
-					latency_critical_stddev      = 110
-					latency_warning_stddev       = 120
-					jitter_critical_stddev       = 130
-					jitter_warning_stddev        = 140
-					http_latency_critical_stddev = 150
-					http_latency_warning_stddev  = 160
+					latency_critical_stddev      = 100
+					latency_warning_stddev       = 100
+					jitter_critical_stddev       = 100
+					jitter_warning_stddev        = 100
+					http_latency_critical_stddev = 100
+					http_latency_warning_stddev  = 100
 				}
 				monitoring_settings {
 					notification_channels = [
@@ -466,21 +466,21 @@ const (
 				}
 				ping {
 					period = 10
-					count  = 20
+					count  = 5
 					expiry = 30
 					delay = 40
 				}
 				trace {
 					period   = 10
-					count    = 20
-					protocol = "quick"
+					count    = 5
+					protocol = "tcp"
 					port     = 40
 					expiry   = 50
 					limit    = 60
 					delay    = 70
 				}
 				port     = 80
-				protocol = "pigeon"
+				protocol = "udp"
 				family   = "IP_FAMILY_V6"
 				servers = [
 					"192.0.2.1"
@@ -488,7 +488,7 @@ const (
 				rollup_level = 10
 				http {
 				  period = 10
-				  expiry = 20
+				  expiry = 5000
 				  method = "POST"
 				  headers = {
 					dummy-header-key = "updated-header-value"

--- a/synthetics/schema.go
+++ b/synthetics/schema.go
@@ -36,6 +36,13 @@ func computedOnRead(mode schemaMode) bool {
 	return mode == readSingle || mode == readList
 }
 
+func skipOnRead(mode schemaMode, diagFunc schema.SchemaValidateDiagFunc) schema.SchemaValidateDiagFunc {
+	if mode == readSingle || mode == readList {
+		return nil
+	}
+	return diagFunc
+}
+
 // makeRequiredNestedObjectSchema returns a list of 1 element to emulate a nested object.
 // See: https://learn.hashicorp.com/tutorials/terraform/provider-create?in=terraform/providers#define-order-schema
 func makeRequiredNestedObjectSchema(mode schemaMode, properties map[string]*schema.Schema) *schema.Schema {

--- a/synthetics/test_schema.go
+++ b/synthetics/test_schema.go
@@ -2,6 +2,7 @@ package synthetics
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 // TODO(dfurman): provide descriptions, when they are specified in the OpenAPI definitions
@@ -70,24 +71,28 @@ func makeTestSettingsSchema(mode schemaMode) *schema.Schema {
 			},
 		},
 		"period": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"count": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"expiry": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"limit": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"tasks": {
 			Type:     schema.TypeList,
@@ -102,9 +107,10 @@ func makeTestSettingsSchema(mode schemaMode) *schema.Schema {
 		"ping":                makeTestPingSchema(mode),
 		"trace":               makeTestTraceSchema(mode),
 		"port": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"protocol": {
 			Type:     schema.TypeString,
@@ -174,14 +180,16 @@ func makeTestFlowSchema(mode schemaMode) *schema.Schema {
 			Computed: computedOnRead(mode),
 		},
 		"target_refresh_interval_millis": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"max_tasks": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"type": {
 			Type:     schema.TypeString,
@@ -334,7 +342,8 @@ func makeTestHealthSettingsSchema(mode schemaMode) *schema.Schema {
 			Optional: true,
 			Computed: computedOnRead(mode),
 			Elem: &schema.Schema{
-				Type: schema.TypeInt,
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 		},
 		"dns_valid_codes": {
@@ -342,7 +351,8 @@ func makeTestHealthSettingsSchema(mode schemaMode) *schema.Schema {
 			Optional: true,
 			Computed: computedOnRead(mode),
 			Elem: &schema.Schema{
-				Type: schema.TypeInt,
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 		},
 		"latency_critical_stddev": {
@@ -461,14 +471,16 @@ func makeTestTraceSchema(mode schemaMode) *schema.Schema {
 func makeTestHTTPSchema(mode schemaMode) *schema.Schema {
 	return makeOptionalNestedObjectSchema(mode, map[string]*schema.Schema{
 		"period": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"expiry": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: computedOnRead(mode),
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     computedOnRead(mode),
+			ValidateFunc: validation.IntAtLeast(0),
 		},
 		"method": {
 			Type:     schema.TypeString,

--- a/synthetics/test_schema.go
+++ b/synthetics/test_schema.go
@@ -121,6 +121,8 @@ func makeTestSettingsSchema(mode schemaMode) *schema.Schema {
 			Type:     schema.TypeString,
 			Required: requiredOnCreate(mode),
 			Computed: computedOnRead(mode),
+			ValidateDiagFunc: skipOnRead(mode, validation.ToDiagFunc(validation.StringInSlice(
+				[]string{"IP_FAMILY_V4", "IP_FAMILY_V6", "IP_FAMILY_DUAL", "IP_FAMILY_UNSP", "ECIFIED"}, false))),
 		},
 		"servers": {
 			Type:     schema.TypeList,
@@ -240,8 +242,21 @@ func makeTestDNSSchema(mode schemaMode) *schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: computedOnRead(mode),
+			ValidateDiagFunc: skipOnRead(mode, validation.ToDiagFunc(validation.StringInSlice(
+				[]string{
+					"DNS_RECORD_UNSPECIFIED", "DNS_RECORD_A", "DNS_RECORD_AAAA", "DNS_RECORD_CNAME",
+					"DNS_RECORD_DNAME", "DNS_RECORD_NS", "DNS_RECORD_MX", "DNS_RECORD_PTR", "DNS_RECORD_SOA",
+				},
+				false))),
 		},
 	})
+}
+
+func skipOnRead(mode schemaMode, diagFunc schema.SchemaValidateDiagFunc) schema.SchemaValidateDiagFunc {
+	if mode != create {
+		return nil
+	}
+	return diagFunc
 }
 
 func makeTestURLSchema(mode schemaMode) *schema.Schema {


### PR DESCRIPTION
KNTK-362
Several properties are represented with different types in TF provider schema than in Kentik API. 
Here focused on TypeInt schema properties represented by uint32 in KentikAPI.
Added validation func.

edit (second commit):
Added validation to string type fields which allowed values are strict defined.

EDIT - task postponed until transition to new version of the synthetics API