### PR TITLE
Additional loggerss on debug level

### DIFF
--- a/synthetics/data_source_agent.go
+++ b/synthetics/data_source_agent.go
@@ -2,8 +2,10 @@ package synthetics
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/kentik/community_sdk_golang/kentikapi"
@@ -19,9 +21,11 @@ func dataSourceAgent() *schema.Resource {
 }
 
 func dataSourceAgentRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	tflog.Debug(ctx, fmt.Sprintf("Kentik API request - read agent with ID: %s\n", d.Get(idKey).(string)))
 	resp, httpResp, err := m.(*kentikapi.Client).SyntheticsAdminServiceAPI.
 		AgentGet(ctx, d.Get(idKey).(string)).
 		Execute()
+	tflog.Debug(ctx, fmt.Sprintf("Kentik API response - read:\n%s\n", httpResp.Body))
 	if err != nil {
 		return detailedDiagError("Failed to read agent", err, httpResp)
 	}

--- a/synthetics/data_source_agents.go
+++ b/synthetics/data_source_agents.go
@@ -2,10 +2,12 @@ package synthetics
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	geo "github.com/kellydunn/golang-geo"
@@ -59,7 +61,9 @@ func dataSourceAgents() *schema.Resource {
 }
 
 func dataSourceAgentsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	tflog.Debug(ctx, "Kentik API request - read agents")
 	resp, httpResp, err := m.(*kentikapi.Client).SyntheticsAdminServiceAPI.AgentsList(ctx).Execute()
+	tflog.Debug(ctx, fmt.Sprintf("Kentik API response - read:\n%s\n", httpResp.Body))
 	if err != nil {
 		return detailedDiagError("Failed to read agents", err, httpResp)
 	}

--- a/synthetics/data_source_test_impl.go
+++ b/synthetics/data_source_test_impl.go
@@ -5,7 +5,9 @@ package synthetics
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/kentik/community_sdk_golang/kentikapi"
@@ -20,9 +22,11 @@ func dataSourceTest() *schema.Resource {
 }
 
 func dataSourceTestRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	tflog.Debug(ctx, fmt.Sprintf("Kentik API request - read test with ID: %s\n", d.Get(idKey).(string)))
 	resp, httpResp, err := m.(*kentikapi.Client).SyntheticsAdminServiceAPI.
 		TestGet(ctx, d.Get(idKey).(string)).
 		Execute()
+	tflog.Debug(ctx, fmt.Sprintf("Kentik API response - read:\n%s\n", httpResp.Body))
 	if err != nil {
 		return detailedDiagError("Failed to read test", err, httpResp)
 	}

--- a/synthetics/data_source_tests.go
+++ b/synthetics/data_source_tests.go
@@ -2,9 +2,11 @@ package synthetics
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/kentik/community_sdk_golang/kentikapi"
@@ -36,7 +38,9 @@ func dataSourceTests() *schema.Resource {
 }
 
 func dataSourceTestsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	tflog.Debug(ctx, "Kentik API request - read tests")
 	resp, httpResp, err := m.(*kentikapi.Client).SyntheticsAdminServiceAPI.TestsList(ctx).Execute()
+	tflog.Debug(ctx, fmt.Sprintf("Kentik API response - read:\n%s\n", httpResp.Body))
 	if err != nil {
 		return detailedDiagError("Failed to read tests", err, httpResp)
 	}


### PR DESCRIPTION
KNTK - 262

Added logging of API requests and responses as suggested in:
https://github.com/kentik/terraform-provider-kentik-synthetics/pull/81#issuecomment-1042346692

Here https://pastebin.com/0qDGqQ1g is a part of debug output containing new loggers.

Similar PR for cloudexport https://github.com/kentik/terraform-provider-kentik-cloudexport/pull/54